### PR TITLE
chore: hierarchical data keys

### DIFF
--- a/frontend/src/composables/notes/useCreateNote.ts
+++ b/frontend/src/composables/notes/useCreateNote.ts
@@ -16,8 +16,8 @@ export const useCreateNote = () =>
     '/notes/',
     {
       method: 'POST',
-      onSuccess: () => {
-        refreshNuxtData('notes');
+      onSuccess: (note) => {
+        invalidateNuxtData(['notes', note.type]);
       },
     },
   );

--- a/frontend/src/composables/notes/useCreateNoteFeedback.ts
+++ b/frontend/src/composables/notes/useCreateNoteFeedback.ts
@@ -15,7 +15,6 @@ interface CreateNoteFeedbackPayload extends Pick<NoteFeedback, 'content'> {
 
 export const useCreateNoteFeedback = ({
   noteId,
-  owner,
 }: UseCreateNoteFeedbackOptions) =>
   useApiMutation<
     CreateNoteFeedbackResponse,
@@ -24,9 +23,6 @@ export const useCreateNoteFeedback = ({
   >(`/notes/${noteId}/feedbacks/`, {
     method: 'POST',
     onSuccess: () => {
-      refreshNuxtData([
-        `note:${noteId}:feedbacks`,
-        `note:${noteId}:feedbacks:${owner}`,
-      ]);
+      invalidateNuxtData(['note-feedbacks', noteId]);
     },
   });

--- a/frontend/src/composables/notes/useCreateNoteSummary.ts
+++ b/frontend/src/composables/notes/useCreateNoteSummary.ts
@@ -29,6 +29,6 @@ export const useCreateNoteSummary = ({
   >(`/notes/${noteId}/summaries/`, {
     method: 'POST',
     onSuccess: () => {
-      refreshNuxtData(`note:${noteId}:summaries`);
+      invalidateNuxtData(['note-summaries', noteId]);
     },
   });

--- a/frontend/src/composables/notes/useDeleteNote.ts
+++ b/frontend/src/composables/notes/useDeleteNote.ts
@@ -10,6 +10,6 @@ export const useDeleteNote = ({ id }: UseDeleteNoteOptions) =>
   useApiMutation<never, DeleteNoteError, never>(`/notes/${id}/`, {
     method: 'DELETE',
     onSuccess: () => {
-      refreshNuxtData('notes');
+      invalidateNuxtData('notes');
     },
   });

--- a/frontend/src/composables/notes/useGetNote.ts
+++ b/frontend/src/composables/notes/useGetNote.ts
@@ -5,4 +5,6 @@ interface UseGetNoteOptions {
 }
 
 export const useGetNote = ({ id }: UseGetNoteOptions) =>
-  useApiFetch<GetNoteResponse>(`/notes/${id}`, { key: `note:${id}` });
+  useApiFetch<GetNoteResponse>(`/notes/${id}`, {
+    key: createNuxtDataKey(['note', id]),
+  });

--- a/frontend/src/composables/notes/useGetNoteFeedbacks.ts
+++ b/frontend/src/composables/notes/useGetNoteFeedbacks.ts
@@ -12,9 +12,7 @@ export const useGetNoteFeedbacks = ({
   enabled,
 }: UseGetNoteFeedbacksOptions) =>
   useApiFetch<GetNoteFeedbacksResponse>(`/notes/${noteId}/feedbacks/`, {
-    key: owner
-      ? `note:${noteId}:feedbacks:${owner}`
-      : `note:${noteId}:feedbacks`,
+    key: createNuxtDataKey(['note-feedbacks', noteId, owner]),
     query: {
       owner,
     },

--- a/frontend/src/composables/notes/useGetNoteSummaries.ts
+++ b/frontend/src/composables/notes/useGetNoteSummaries.ts
@@ -6,5 +6,5 @@ interface UseGetNoteSummariesOptions {
 
 export const useGetNoteSummaries = ({ noteId }: UseGetNoteSummariesOptions) =>
   useApiFetch<GetNoteSummariesResponse>(`/notes/${noteId}/summaries/`, {
-    key: `note:${noteId}:summaries`,
+    key: createNuxtDataKey(['note-summaries', noteId]),
   });

--- a/frontend/src/composables/notes/useGetNotes.ts
+++ b/frontend/src/composables/notes/useGetNotes.ts
@@ -10,9 +10,9 @@ export const useGetNotes = ({
   type,
   user,
   retrieveMentions,
-}: UseGetNotesOptions) =>
+}: UseGetNotesOptions = {}) =>
   useApiFetch<GetNotesResponse>('/notes/', {
-    key: 'notes',
+    key: createNuxtDataKey(['notes', type, user, retrieveMentions]),
     query: {
       type,
       user,

--- a/frontend/src/composables/notes/useUpdateNote.ts
+++ b/frontend/src/composables/notes/useUpdateNote.ts
@@ -19,8 +19,9 @@ export const useUpdateNote = ({ id }: UseUpdateNoteOptions) =>
     `/notes/${id}/`,
     {
       method: 'PATCH',
-      onSuccess: () => {
-        refreshNuxtData(`note:${id}`);
+      onSuccess: (note) => {
+        invalidateNuxtData(['note', id]);
+        invalidateNuxtData(['notes', note.type])
       },
     },
   );

--- a/frontend/src/utils/createNuxtDataKey.ts
+++ b/frontend/src/utils/createNuxtDataKey.ts
@@ -1,0 +1,7 @@
+/**
+ * Create a key to use for Nuxt data (`useFetch`, `useLazyFetch`, etc.) from a hierarchical data key
+ * @param dataKey a data key or array of hierarchical keys
+ * @returns Unique key in the form of `dataKey[0]:dataKey[1]:...:dataKey[n]`
+ */
+export const createNuxtDataKey = (dataKey: string | unknown[]): string =>
+  Array.isArray(dataKey) ? dataKey.map((k) => k ?? '').join(':') : dataKey;

--- a/frontend/src/utils/invalidateNuxtData.ts
+++ b/frontend/src/utils/invalidateNuxtData.ts
@@ -1,0 +1,14 @@
+/**
+ * Call `refreshNuxtData` for each key matching the given hierarchical data key
+ * @param dataKey Data key or array of keys
+ * @returns Promise that resolves when all keys have been invalidated
+ */
+export const invalidateNuxtData = (
+  dataKey: string | unknown[],
+): Promise<void> => {
+  const key = createNuxtDataKey(dataKey);
+  const availableKeys = Object.keys(useNuxtApp().payload.data);
+  const invalidateKeys = availableKeys.filter((k) => k.startsWith(key));
+
+  return refreshNuxtData(invalidateKeys);
+};


### PR DESCRIPTION
* Implement utils to handle hierarchical data keys for nuxt data
  * `createNuxtDataKey`: inputs a hierarchical `dataKey` array and creates a string used for nuxt data in the format of `"dataKey[0]:dataKey[1]:...:dataKey[n]"`.
  * `invalidateNuxtData`: call `refreshNuxtData` for each key matching the given hierarchical data key
* Use these utils to handle hierarchical data fetching invalidations