### PR TITLE
feat: implement store and load form drafts

### DIFF
--- a/frontend/src/components/note/NoteForm.vue
+++ b/frontend/src/components/note/NoteForm.vue
@@ -174,6 +174,7 @@ const {
   values: formValues,
   handleSubmit,
   setFieldValue,
+  setValues,
 } = useForm<NoteFormValues>({
   initialValues: {
     title: props.note?.title || '',
@@ -185,8 +186,27 @@ const {
     linked_notes: props.note?.linked_notes || [],
   },
 });
-useUnsavedChangesGuard({ disabled: () => !meta.value.dirty });
 const { data: notes, pending: isNotesLoading } = useGetNotes();
+
+const isEditing = computed(() => Boolean(props.note));
+
+useUnsavedChangesGuard({
+  disabled: () => !isEditing.value || !meta.value.dirty,
+});
+useStoreDraft({
+  disabled: isEditing,
+  storageKey: () => `note:draft:${props.noteType}`,
+  values: computed(() => ({
+    title: formValues.title,
+    content: formValues.content,
+  })),
+  setValues: (values) =>
+    setValues({
+      ...formValues,
+      title: values.title,
+      content: values.content,
+    }),
+});
 
 const noteOptions = computed(() =>
   notes.value

--- a/frontend/src/components/note/NoteTemplateForm.vue
+++ b/frontend/src/components/note/NoteTemplateForm.vue
@@ -24,11 +24,7 @@
     </VeeField>
 
     <VeeField v-slot="{ componentField }" name="mentioned_users">
-      <UserSelect
-        v-bind="componentField"
-        :label="t('note.share')"
-        multiple
-      />
+      <UserSelect v-bind="componentField" :label="t('note.share')" multiple />
     </VeeField>
 
     <div class="flex flex-wrap items-center justify-end gap-4 pt-8">
@@ -72,14 +68,38 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { meta, handleSubmit } = useForm<NoteTemplateFormValues>({
+const {
+  meta,
+  values: formValues,
+  handleSubmit,
+  setValues,
+} = useForm<NoteTemplateFormValues>({
   initialValues: {
     title: props.note?.title || '',
     content: props.note?.content || '',
     mentioned_users: props.note?.mentioned_users || [],
   },
 });
-useUnsavedChangesGuard({ disabled: () => !meta.value.dirty });
+
+const isEditing = computed(() => Boolean(props.note));
+
+useUnsavedChangesGuard({
+  disabled: () => !isEditing.value || !meta.value.dirty,
+});
+useStoreDraft({
+  disabled: isEditing,
+  storageKey: 'note:draft:Template',
+  values: computed(() => ({
+    title: formValues.title,
+    content: formValues.content,
+  })),
+  setValues: (values) =>
+    setValues({
+      ...formValues,
+      title: values.title,
+      content: values.content,
+    }),
+});
 
 const onSubmit = handleSubmit((values, ctx) => {
   emit('submit', values, ctx);

--- a/frontend/src/composables/useStoreDraft.ts
+++ b/frontend/src/composables/useStoreDraft.ts
@@ -1,0 +1,45 @@
+interface UseStoreDraftOptions<T> {
+  disabled?: MaybeRefOrGetter<boolean> | ComputedRef<boolean>;
+  setValues: (values: T) => void;
+  storageKey: string | MaybeRefOrGetter<string> | ComputedRef<string>;
+  values: T | ComputedRef<T>;
+}
+
+export const useStoreDraft = <T>({
+  disabled,
+  values,
+  setValues,
+  storageKey,
+}: UseStoreDraftOptions<T>) => {
+  onMounted(() => {
+    if (toValue(disabled)) {
+      return;
+    }
+
+    try {
+      const draft = localStorage.getItem(toValue(storageKey));
+
+      if (draft) {
+        setValues(JSON.parse(draft));
+      }
+    } catch (e) {
+      localStorage.removeItem(toValue(storageKey));
+    }
+  });
+
+  watch(
+    () => values,
+    // TODO: debounce this
+    (values) => {
+      if (toValue(disabled)) {
+        return;
+      }
+
+      localStorage.setItem(
+        toValue(storageKey),
+        JSON.stringify(toValue(values)),
+      );
+    },
+    { deep: true },
+  );
+};

--- a/frontend/src/composables/useUnsavedChangesGuard.ts
+++ b/frontend/src/composables/useUnsavedChangesGuard.ts
@@ -1,8 +1,10 @@
 interface UseUnsavedChangesGuardOptions {
-  disabled?: () => boolean | Ref<boolean>;
+  disabled?: boolean | MaybeRefOrGetter<boolean> | ComputedRef<boolean>;
 }
 
-export const useUnsavedChangesGuard = ({ disabled }: UseUnsavedChangesGuardOptions = {}) => {
+export const useUnsavedChangesGuard = ({
+  disabled,
+}: UseUnsavedChangesGuardOptions = {}) => {
   const handleBeforeUnload = (event: BeforeUnloadEvent) => {
     if (!toValue(disabled)) {
       event.preventDefault();


### PR DESCRIPTION
Implement a composable to store drafts of "create note" forms to localStorage and load them on mount.