### PR TITLE
fix: fix form result display + add related tests

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,0 +1,156 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.utils import timezone
+from datetime import timedelta
+from api.models import Form, FormAssignment, User, Cycle, FormResponse, Question
+
+class FormResultsAPITestCase(APITestCase):
+    
+    def setUp(self):
+        # Create a cycle that ended in the past
+        self.cycle = Cycle.objects.create(
+            name="Test Cycle",
+            start_date=timezone.now() - timedelta(days=10),
+            end_date=timezone.now() - timedelta(days=5)
+        )
+
+        # Create unique users for testing
+        self.user_leader = User.objects.create(email="leader_1@example.com", password="password123", name="Leader User")
+        self.user_member = User.objects.create(email="member_1@example.com", password="password123", name="Member User")
+        
+        # Create a default form (results shown after cycle.end_date)
+        self.form_default = Form.objects.create(
+            name="Default Form",
+            is_default=True,
+            form_type="TL",
+            cycle=self.cycle
+        )
+
+        # Create a manually assigned form (results shown after assignment deadline)
+        self.form_manual = Form.objects.create(
+            name="Manual Form",
+            is_default=False,
+            form_type="PM",
+            cycle=self.cycle
+        )
+
+        # Create questions for the form
+        self.question_default = Question.objects.create(
+            form=self.form_default,
+            question_text="Test Default Q1?",
+            category="Cat.1",
+            scale_min=1,
+            scale_max=5
+        )
+        self.question_manual = Question.objects.create(
+            form=self.form_manual,
+            question_text="Test Manual Q2?",
+            category="Cat.2",
+            scale_min=1,
+            scale_max=5
+        )
+
+        # Assign form to user as assigned_by (leader)
+        self.assignment_default = FormAssignment.objects.create(
+            form=self.form_default,
+            assigned_to=self.user_member,
+            assigned_by=self.user_leader,
+            deadline=self.cycle.end_date    # Passed
+        )
+
+        # For manual form, create two assignments:
+        # One with a passed deadline...
+        self.assignment_manual_passed = FormAssignment.objects.create(
+            form=self.form_manual,
+            assigned_to=self.user_member,
+            assigned_by=self.user_leader,
+            deadline=timezone.now().date() - timedelta(days=1)  # Passed
+        )
+        # ...and one with a future deadline.
+        self.assignment_manual_future = FormAssignment.objects.create(
+            form=self.form_manual,
+            assigned_to=self.user_member,
+            assigned_by=self.user_leader,
+            deadline=timezone.now().date() + timedelta(days=1)  # Not passed
+        )
+
+        # Create responses for the user member
+        FormResponse.objects.create(
+            form=self.form_default,
+            user=self.user_member,
+            question=self.question_default,
+            answer="5",
+            date_created=timezone.now()
+        )
+
+        FormResponse.objects.create(
+            form=self.form_manual,
+            user=self.user_member,
+            question=self.question_manual,
+            answer="3",
+            date_created=timezone.now()
+        )
+
+    def test_results_with_invalid_cycle(self):
+        """Test that results are blocked if cycle has not ended"""
+        # Set cycle end date to a future date (for this test)
+        future_cycle = Cycle.objects.create(
+            name="Future Test Cycle",
+            start_date=timezone.now(),
+            end_date=timezone.now() + timedelta(days=10)
+        )
+        url = f"/api/forms/{self.form_default.id}/results/?cycle_id={future_cycle.id}"
+        
+        # Leader is assigned_by, so they can view the results
+        self.client.force_authenticate(user=self.user_leader)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Results for this form are not available until the cycle ends.")
+    
+    def test_results_with_valid_cycle_and_assigned_by_default(self):
+        """
+        For a default form, since the cycle has ended and the assignment deadline is met,
+        the assigned_by user should get a 200 OK response with aggregated results.
+        """
+        url = f"/api/forms/{self.form_default.id}/results/?cycle_id={self.cycle.id}"
+        self.client.force_authenticate(user=self.user_leader)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("total_average", response.data)
+
+    def test_results_with_valid_cycle_and_assigned_by_manual(self):
+        """
+        For a manually assigned form with a passed deadline (assignment_manual_passed),
+        the assigned_by user should receive a 200 OK response.
+        """
+        url = f"/api/forms/{self.form_manual.id}/results/?cycle_id={self.cycle.id}"
+        self.client.force_authenticate(user=self.user_leader)
+        # Both assignments exist; this query should pick the one with deadline <= today.
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("total_average", response.data)
+
+    def test_results_without_permission(self):
+        """
+        A user who is not the assigned_by (i.e. not the assessor) should get a 403 Forbidden.
+        """
+        url = f"/api/forms/{self.form_default.id}/results/?cycle_id={self.cycle.id}"
+        self.client.force_authenticate(user=self.user_member)  # Not the assigned_by
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["detail"], "You are not authorized to view results for this form.")
+
+    def test_results_with_deadline_not_met_manual(self):
+        """
+        For a manually assigned form, if the only assignment has a future deadline,
+        results should not be shown and a 400 error is returned.
+        """
+        # Remove the passed-deadline assignment so that only the future one remains.
+        self.assignment_manual_passed.delete()
+        
+        url = f"/api/forms/{self.form_manual.id}/results/?cycle_id={self.cycle.id}"
+        self.client.force_authenticate(user=self.user_leader)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Results for this form are not available until the deadline passes", response.data["detail"])


### PR DESCRIPTION
This pull request addresses a bug in the form assessment feature where the results were not being displayed correctly. The fix ensures that:

- Results are only shown after the cycle end date for default forms, or after the assignment deadline for manually assigned forms.
- Users can view results only if they are the assigned_by for the form (ensuring the results are kept anonymous).

**Changes included in this PR:**

- Fixed the result display logic in FormViewSet by validating the cycle end date or assignment deadline before showing results.
- Updated the handling of form assignments for both default and non-default forms to correctly filter results based on deadlines.
- Added additional validation to ensure results are only visible to the assigned_by user.

**Why is this PR needed?**

- Previously, form results were being shown even when the relevant deadlines or cycle end dates hadn’t passed, leading to incorrect result visibility. 
- This bug fix ensures that results are only accessible when they should be, adhering to the business logic around deadlines and assignments.
- There was a serious risk of data leak in the previous version.

**Testing Done:**

- Manual testing via Postman confirmed that results are only accessible to the assessed user, and only after the deadlines are passed for both default and non-default forms.
- Unit tests were written to cover scenarios like viewing results before the deadline and unauthorized access attempts.