### PR TITLE
Remove the logic for making note inaccessible

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -516,8 +516,6 @@ class NoteUserAccess(MerlinBaseModel):
                     note=note,
                     defaults=leader_permissions[note.type],
                 )
-            else:
-                cls.make_note_inaccessible_if_not(leader, note)
 
         # Agile Coach
         cls.objects.update_or_create(
@@ -550,8 +548,6 @@ class NoteUserAccess(MerlinBaseModel):
                             "can_view_feedbacks": True,
                         },
                     )
-                else:
-                    cls.make_note_inaccessible_if_not(member, note)
 
         # Mentioned users
         for user in note.mentioned_users.all():


### PR DESCRIPTION
This PR resolves the bug when admin has given a random user some random permissions which is not defined in the code. In some situations, the code tries to take these permissions away from that random user because it thinks there was a mistake.